### PR TITLE
fix(package-registry): strip ansi codes from outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## v2.3.0
 
 ### Added
-- **Sync Diff Views:** Added `mntn sync --diff` to show combined unstaged and staged changes.
+- **Sync Diff Views:** Added `mntn sync --diff` and `mntn sync --diff-stat` to show combined unstaged and staged changes.
   - Uses `--cached` fallback for older git versions when showing staged diffs.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project are documented in this file.
 ## v2.3.0
 
 ### Added
-- **Sync Diff Views:** Added `mntn sync --diff` and `mntn sync --diff-stat` to show combined unstaged and staged changes.
+- **Sync Diff Views:** Added `mntn sync --diff` to show combined unstaged and staged changes.
   - Uses `--cached` fallback for older git versions when showing staged diffs.
 
 ### Fixed
-- **Package Registry Output:** Strips ANSI escape codes from package registry command output to keep `mntn ls -g` clean.
+- **Package Registry Output:** Strips ANSI escape codes from package registry command output to keep package registry output clean.
 ## v2.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - **Package Registry Output:** Strips ANSI escape codes from package registry command output to keep package registry output clean.
+
 ## v2.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## v2.3.0
+
+### Added
+- **Sync Diff Views:** Added `mntn sync --diff` and `mntn sync --diff-stat` to show combined unstaged and staged changes.
+  - Uses `--cached` fallback for older git versions when showing staged diffs.
+
+### Fixed
+- **Package Registry Output:** Strips ANSI escape codes from package registry command output to keep `mntn ls -g` clean.
 ## v2.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## v2.3.0
 
 ### Added
-- **Sync Diff Views:** Added `mntn sync --diff` and `mntn sync --diff-stat` to show combined unstaged and staged changes.
+- **Sync Diff Views:** Added `mntn sync --diff` to show combined unstaged and staged changes.
   - Uses `--cached` fallback for older git versions when showing staged diffs.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
  "shellexpand",
  "signal-hook 0.4.3",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "trash",
  "which",
  "whoami",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ name = "mntn"
 version = "2.2.0"
 dependencies = [
  "age",
+ "anyhow",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -1106,6 +1107,7 @@ dependencies = [
  "shellexpand",
  "signal-hook 0.4.3",
  "tempfile",
+ "thiserror 1.0.69",
  "trash",
  "which",
  "whoami",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,10 +124,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.8.0"
+name = "anyhow"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arc-swap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
@@ -188,9 +194,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -228,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -252,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -262,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -274,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -286,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -578,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fluent"
@@ -625,6 +631,12 @@ checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures"
@@ -746,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -757,14 +769,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -772,6 +785,15 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -871,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -894,13 +916,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -914,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
+checksum = "979f5ab9760427ada4fa5762b2d905e5b12704fb1fada07b6bfa66aeaa586f87"
 dependencies = [
  "bitflags",
  "crossterm",
@@ -965,9 +995,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -978,6 +1008,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1024,9 +1060,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -1068,7 +1104,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "shellexpand",
- "signal-hook 0.4.1",
+ "signal-hook 0.4.3",
  "tempfile",
  "trash",
  "which",
@@ -1087,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1260,6 +1296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1301,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1341,7 +1387,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1379,7 +1425,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1390,16 +1436,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1409,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1420,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rpassword"
@@ -1447,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1458,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1471,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1706,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a37d01603c37b5466f808de79f845c7116049b0579adb70a6b7d47c1fa3a952"
+checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1737,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1772,12 +1818,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1794,11 +1840,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1814,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1834,30 +1880,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1937,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1952,6 +1998,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -2008,9 +2060,18 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2026,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2039,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2049,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2062,18 +2123,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2092,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a0d55c8d8f68772be4533e238da83f3a7adada2a85f2c3059099e5f054ebc4"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
 dependencies = [
  "libredox",
  "wasite",
@@ -2343,9 +2438,91 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -2361,18 +2538,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2417,6 +2594,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,9 +1017,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 age = "0.11.2"
+anyhow = "1.0.83"
 base64 = "0.22"
 chrono = "0.4.42"
 gethostname = "1.1.0"
@@ -39,6 +40,7 @@ which = "8.0.0"
 whoami = "2.0.0"
 libc = "0.2.178"
 signal-hook = "0.4.1"
+thiserror = "1.0.69"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ which = "8.0.0"
 whoami = "2.0.0"
 libc = "0.2.178"
 signal-hook = "0.4.1"
-thiserror = "1.0.69"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ mntn sync --init --remote-url https://github.com/yourusername/dotfiles.git
 # Pull latest changes
 mntn sync --pull
 
+# Show diffs before syncing (uses --cached fallback for staged diffs)
+mntn sync --diff
+mntn sync --diff-stat
+
 # Push local changes
 mntn sync --push --message "Update configs"
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ mntn sync --pull
 
 # Show diffs before syncing (uses --cached fallback for staged diffs)
 mntn sync --diff
+mntn sync --diff-stat
 
 # Push local changes
 mntn sync --push --message "Update configs"

--- a/README.md
+++ b/README.md
@@ -367,7 +367,6 @@ mntn sync --pull
 
 # Show diffs before syncing (uses --cached fallback for staged diffs)
 mntn sync --diff
-mntn sync --diff-stat
 
 # Push local changes
 mntn sync --push --message "Update configs"

--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ mntn sync --init --remote-url https://github.com/yourusername/dotfiles.git
 # Pull latest changes
 mntn sync --pull
 
+# Show status before syncing
+mntn sync --status
+
 # Show diffs before syncing (uses --cached fallback for staged diffs)
 mntn sync --diff
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,9 +226,6 @@ pub struct SyncArgs {
     /// Show git diff for the repository (full changes)
     #[arg(long, help = "Show git diff for the repository (full changes)")]
     pub diff: bool,
-    /// Show git diff summary for the repository
-    #[arg(long, help = "Show git diff --stat for the repository")]
-    pub diff_stat: bool,
 }
 
 /// Arguments for the registry command.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -223,6 +223,12 @@ pub struct SyncArgs {
     /// Show git status for the repository
     #[arg(long, help = "Show git status for the repository")]
     pub status: bool,
+    /// Show git diff for the repository (full changes)
+    #[arg(long, help = "Show git diff for the repository (full changes)")]
+    pub diff: bool,
+    /// Show git diff summary for the repository
+    #[arg(long, help = "Show git diff --stat for the repository")]
+    pub diff_stat: bool,
 }
 
 /// Arguments for the registry command.

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,4 +1,5 @@
 use age::secrecy::SecretString;
+use anyhow::{Context, Result, bail};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -7,17 +8,19 @@ use std::path::Path;
 
 /// Prompts the user for a password securely (input is hidden)
 /// If `confirm` is true, asks for password confirmation
-pub fn prompt_password(confirm: bool) -> Result<SecretString, Box<dyn std::error::Error>> {
-    let password = rpassword::prompt_password("Enter encryption password: ")?;
+pub fn prompt_password(confirm: bool) -> Result<SecretString> {
+    let password =
+        rpassword::prompt_password("Enter encryption password: ").context("Read password")?;
 
     if password.is_empty() {
-        return Err("Password cannot be empty".into());
+        bail!("Password cannot be empty");
     }
 
     if confirm {
-        let confirmation = rpassword::prompt_password("Confirm encryption password: ")?;
+        let confirmation = rpassword::prompt_password("Confirm encryption password: ")
+            .context("Read password confirmation")?;
         if password != confirmation {
-            return Err("Passwords do not match".into());
+            bail!("Passwords do not match");
         }
     }
 
@@ -26,56 +29,63 @@ pub fn prompt_password(confirm: bool) -> Result<SecretString, Box<dyn std::error
 }
 
 /// Encrypts a file using age with password-based encryption
-pub fn encrypt_file(
-    source: &Path,
-    dest: &Path,
-    password: &SecretString,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let content = fs::read(source)?;
+pub fn encrypt_file(source: &Path, dest: &Path, password: &SecretString) -> Result<()> {
+    let content = fs::read(source)
+        .with_context(|| format!("Read source file for encryption: {}", source.display()))?;
 
     let encryptor = age::Encryptor::with_user_passphrase(password.clone());
 
     if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Create parent directory: {}", parent.display()))?;
     }
 
     let mut encrypted = vec![];
-    let mut writer = encryptor.wrap_output(&mut encrypted)?;
-    writer.write_all(&content)?;
-    writer.finish()?;
+    let mut writer = encryptor
+        .wrap_output(&mut encrypted)
+        .context("Initialize encryptor")?;
+    writer
+        .write_all(&content)
+        .context("Write encrypted content")?;
+    writer.finish().context("Finalize encryption output")?;
 
-    fs::write(dest, encrypted)?;
+    fs::write(dest, encrypted)
+        .with_context(|| format!("Write encrypted file: {}", dest.display()))?;
     Ok(())
 }
 
 /// Decrypts a file using age with password-based encryption
-pub fn decrypt_file(
-    source: &Path,
-    dest: &Path,
-    password: &SecretString,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let encrypted = fs::read(source)?;
+pub fn decrypt_file(source: &Path, dest: &Path, password: &SecretString) -> Result<()> {
+    let encrypted = fs::read(source)
+        .with_context(|| format!("Read encrypted file for decryption: {}", source.display()))?;
 
-    let decryptor = age::Decryptor::new(&encrypted[..])?;
+    let decryptor = age::Decryptor::new(&encrypted[..]).context("Create decryptor")?;
 
     let identity = age::scrypt::Identity::new(password.clone());
 
     let mut decrypted = vec![];
-    let mut reader = decryptor.decrypt(std::iter::once(&identity as &dyn age::Identity))?;
-    reader.read_to_end(&mut decrypted)?;
+    let mut reader = decryptor
+        .decrypt(std::iter::once(&identity as &dyn age::Identity))
+        .context("Decrypt payload")?;
+    reader
+        .read_to_end(&mut decrypted)
+        .context("Read decrypted payload")?;
 
     if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Create parent directory: {}", parent.display()))?;
     }
 
-    fs::write(dest, decrypted)?;
+    fs::write(dest, decrypted)
+        .with_context(|| format!("Write decrypted file: {}", dest.display()))?;
 
     // Set restrictive permissions on sensitive files (Unix only)
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let permissions = std::fs::Permissions::from_mode(0o600);
-        fs::set_permissions(dest, permissions)?;
+        fs::set_permissions(dest, permissions)
+            .with_context(|| format!("Set permissions on: {}", dest.display()))?;
     }
 
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, AppError>;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Utf8(#[from] std::string::FromUtf8Error),
+    #[error(transparent)]
+    Inquire(#[from] inquire::error::InquireError),
+    #[error("Command '{cmd}' failed with status {status:?}: {stderr}")]
+    CommandFailure {
+        cmd: String,
+        status: Option<i32>,
+        stderr: String,
+    },
+    #[error("Registry entry '{id}' not found")]
+    RegistryEntryNotFound { id: String },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod encryption;
+mod error;
 mod logger;
 mod profile;
 mod registries;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,3 +1,4 @@
+use crate::error::{AppError, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, collections::HashMap, path::PathBuf};
 
@@ -34,7 +35,7 @@ where
     T: RegistryEntryLike + Clone + Serialize + for<'a> Deserialize<'a>,
 {
     /// Load registry from file, creating default if it doesn't exist
-    pub fn load_or_create(path: &PathBuf) -> Result<Self, Box<dyn std::error::Error>>
+    pub fn load_or_create(path: &PathBuf) -> Result<Self>
     where
         Self: Default,
     {
@@ -50,7 +51,7 @@ where
     }
 
     /// Save registry to file with entries sorted alphabetically by key
-    pub fn save(&self, path: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn save(&self, path: &PathBuf) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -83,13 +84,13 @@ where
     }
 
     /// Enable/disable an entry
-    pub fn set_entry_enabled(&mut self, id: &str, enabled: bool) -> Result<(), String> {
+    pub fn set_entry_enabled(&mut self, id: &str, enabled: bool) -> Result<()> {
         match self.entries.get_mut(id) {
             Some(entry) => {
                 entry.set_enabled(enabled);
                 Ok(())
             }
-            None => Err(format!("Entry '{}' not found", id)),
+            None => Err(AppError::RegistryEntryNotFound { id: id.to_string() }),
         }
     }
 
@@ -102,6 +103,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::AppError;
     use std::fs;
     use tempfile::TempDir;
 
@@ -448,7 +450,10 @@ mod tests {
         let result = registry.set_entry_enabled("nonexistent", true);
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not found"));
+        assert!(matches!(
+            result.unwrap_err(),
+            AppError::RegistryEntryNotFound { .. }
+        ));
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -235,7 +235,7 @@ mod tests {
 
         fs::write(&registry_path, "{ invalid json }").unwrap();
 
-        let result: Result<Registry<TestEntry>, _> = Registry::load_or_create(&registry_path);
+        let result: Result<Registry<TestEntry>> = Registry::load_or_create(&registry_path);
         assert!(result.is_err());
     }
 

--- a/src/tasks/backup.rs
+++ b/src/tasks/backup.rs
@@ -8,7 +8,7 @@ use crate::tasks::core::{PlannedOperation, Task};
 use crate::utils::paths::{
     get_encrypted_registry_path, get_package_registry_path, get_packages_dir, get_registry_path,
 };
-use crate::utils::system::{rsync_directory, run_cmd};
+use crate::utils::system::{rsync_directory, run_cmd, strip_ansi_codes};
 use age::secrecy::SecretString;
 use rayon::prelude::*;
 use std::fs;
@@ -171,6 +171,7 @@ fn backup_package_managers(package_managers_dir: &Path) {
     for (id, entry, result) in results {
         match result {
             Ok(content) => {
+                let content = strip_ansi_codes(&content);
                 let output_path = package_managers_dir.join(&entry.output_file);
                 let tmp_path = output_path.with_extension("tmp");
 

--- a/src/tasks/backup.rs
+++ b/src/tasks/backup.rs
@@ -34,7 +34,7 @@ impl Task for BackupTask {
         "Backup"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         let backup_dir = self.profile.get_backup_path();
         fs::create_dir_all(&backup_dir)?;
 

--- a/src/tasks/biometric_sudo.rs
+++ b/src/tasks/biometric_sudo.rs
@@ -19,7 +19,7 @@ impl Task for BiometricSudoTask {
         "Biometric Sudo"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("🔐 Configuring Touch ID for sudo...");
         log("Starting Touch ID sudo configuration");
 
@@ -30,7 +30,7 @@ impl Task for BiometricSudoTask {
             }
             Err(e) => {
                 log_error("Failed to configure Touch ID for sudo", &e);
-                Err(Box::new(e))
+                Err(e.into())
             }
         }
     }

--- a/src/tasks/clean.rs
+++ b/src/tasks/clean.rs
@@ -29,7 +29,7 @@ impl Task for CleanTask {
         "Clean"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("🧹 Cleaning system junk...");
 
         let args = CleanArgs {

--- a/src/tasks/configs_registry.rs
+++ b/src/tasks/configs_registry.rs
@@ -21,7 +21,7 @@ impl Task for ConfigsRegistryTask {
         "Configs Registry"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         match &self.args.action {
             ConfigsRegistryActions::List { enabled_only } => {
                 list_entries(*enabled_only);

--- a/src/tasks/core.rs
+++ b/src/tasks/core.rs
@@ -1,4 +1,5 @@
 use crate::logger::{log, log_error};
+use anyhow::Result;
 
 /// Represents a planned operation that a task would perform
 #[derive(Debug, Clone)]
@@ -29,7 +30,7 @@ pub trait Task {
     fn name(&self) -> &str;
 
     /// Execute the task
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>>;
+    fn execute(&mut self) -> Result<()>;
 
     /// Preview what the task would do (for dry-run mode)
     fn dry_run(&self) -> Vec<PlannedOperation>;
@@ -75,8 +76,6 @@ impl TaskExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
-
     use super::*;
 
     #[test]
@@ -158,7 +157,7 @@ mod tests {
             &self.name
         }
 
-        fn execute(&mut self) -> Result<(), Box<dyn Error>> {
+        fn execute(&mut self) -> Result<()> {
             self.executed = true;
             Ok(())
         }
@@ -263,7 +262,7 @@ mod tests {
             &self.name
         }
 
-        fn execute(&mut self) -> Result<(), Box<dyn Error>> {
+        fn execute(&mut self) -> anyhow::Result<()> {
             self.execute_count += 1;
             Ok(())
         }

--- a/src/tasks/delete.rs
+++ b/src/tasks/delete.rs
@@ -51,7 +51,7 @@ impl Task for DeleteTask {
         "Delete"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         if self.args.permanent {
             println!("Permanently deleting application and related files...");
         } else {

--- a/src/tasks/encrypted_configs_registry.rs
+++ b/src/tasks/encrypted_configs_registry.rs
@@ -23,7 +23,7 @@ impl Task for EncryptedConfigsRegistryTask {
         "Encrypted Configs Registry"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         match &self.args.action {
             EncryptedRegistryActions::List { enabled_only } => {
                 list_entries(*enabled_only);

--- a/src/tasks/install.rs
+++ b/src/tasks/install.rs
@@ -27,7 +27,7 @@ impl Task for InstallTask {
         "Install"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("Installing scheduled tasks...");
 
         let mut tasks: Vec<ScheduledTask> = vec![ScheduledTask::backup_hourly()];
@@ -123,7 +123,7 @@ impl ScheduledTask {
         }
     }
 
-    fn install(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn install(&self) -> anyhow::Result<()> {
         #[cfg(target_os = "macos")]
         {
             self.install_launchd()
@@ -139,7 +139,7 @@ impl ScheduledTask {
     }
 
     #[cfg(target_os = "macos")]
-    fn install_launchd(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn install_launchd(&self) -> anyhow::Result<()> {
         let binary_path = which(&self.binary)?.to_str().unwrap().to_string();
         let base_dirs = get_base_dirs();
         let home_dir = base_dirs.home_dir();
@@ -184,7 +184,7 @@ impl ScheduledTask {
     }
 
     #[cfg(target_os = "linux")]
-    fn install_systemd_user(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn install_systemd_user(&self) -> anyhow::Result<()> {
         let binary_path = which(&self.binary)?.to_str().unwrap().to_string();
         let base_dirs = get_base_dirs();
         let config_dir = base_dirs.config_dir();
@@ -232,7 +232,7 @@ impl ScheduledTask {
     }
 
     #[cfg(target_os = "windows")]
-    fn install_windows(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn install_windows(&self) -> anyhow::Result<()> {
         let binary_path = which(&self.binary)?.to_str().unwrap().to_string();
         let task_name = format!("mntn-{}", self.label);
         let mut schedule = String::from("HOURLY");

--- a/src/tasks/migrate.rs
+++ b/src/tasks/migrate.rs
@@ -165,7 +165,7 @@ impl Task for MigrateTask {
         "Migrate"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("Migrating legacy backup files to common/...");
 
         // First, clean up any legacy symlinks at target locations

--- a/src/tasks/package_registry.rs
+++ b/src/tasks/package_registry.rs
@@ -20,7 +20,7 @@ impl Task for PackageRegistryTask {
         "Package Registry"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         match &self.args.action {
             PackageRegistryActions::List {
                 enabled_only,

--- a/src/tasks/purge.rs
+++ b/src/tasks/purge.rs
@@ -59,7 +59,7 @@ impl Task for PurgeTask {
         "Purge"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         #[cfg(target_os = "macos")]
         println!("🧼 Listing all launch agents and daemons...");
         #[cfg(target_os = "linux")]

--- a/src/tasks/restore.rs
+++ b/src/tasks/restore.rs
@@ -29,7 +29,7 @@ impl Task for RestoreTask {
         "Restore"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("Starting restore process...");
         println!("   Profile: {}", self.profile);
 

--- a/src/tasks/sync.rs
+++ b/src/tasks/sync.rs
@@ -19,6 +19,8 @@ pub struct SyncTask {
     pub auto_restore: bool,
     pub dry_run: bool,
     pub status: bool,
+    pub diff: bool,
+    pub diff_stat: bool,
 }
 
 impl SyncTask {
@@ -33,6 +35,8 @@ impl SyncTask {
             auto_restore: args.auto_restore,
             dry_run: args.dry_run,
             status: args.status,
+            diff: args.diff,
+            diff_stat: args.diff_stat,
         }
     }
 }
@@ -53,10 +57,20 @@ impl Task for SyncTask {
             auto_restore: self.auto_restore,
             dry_run: self.dry_run,
             status: self.status,
+            diff: self.diff,
+            diff_stat: self.diff_stat,
         };
 
         if args.status {
             show_git_status()?;
+            if !args.diff && !args.diff_stat {
+                return Ok(());
+            }
+        }
+
+        if args.diff || args.diff_stat {
+            let show_stat_only = args.diff_stat && !args.diff;
+            show_git_diff(show_stat_only)?;
             return Ok(());
         }
 
@@ -68,6 +82,23 @@ impl Task for SyncTask {
     fn dry_run(&self) -> Vec<PlannedOperation> {
         let mut operations = Vec::new();
         let mntn_dir = get_mntn_dir();
+
+        if self.status {
+            operations.push(PlannedOperation::new("Show git status"));
+            if !self.diff && !self.diff_stat {
+                return operations;
+            }
+        }
+
+        if self.diff || self.diff_stat {
+            let label = if self.diff_stat && !self.diff {
+                "Show git diff summary"
+            } else {
+                "Show git diff"
+            };
+            operations.push(PlannedOperation::new(label));
+            return operations;
+        }
 
         if self.init {
             operations.push(PlannedOperation::with_target(
@@ -217,6 +248,35 @@ fn show_git_status() -> Result<(), Box<dyn std::error::Error>> {
     let mntn_dir = get_mntn_dir();
     let output = run_cmd_in_dir("git", &["status", "--short", "--branch"], &mntn_dir)?;
     println!("{}", output);
+    Ok(())
+}
+
+fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let mntn_dir = get_mntn_dir();
+    let (unstaged_args, staged_args) = if show_stat_only {
+        (vec!["diff", "--stat"], vec!["diff", "--staged", "--stat"])
+    } else {
+        (vec!["diff"], vec!["diff", "--staged"])
+    };
+
+    let unstaged = run_cmd_in_dir("git", &unstaged_args, &mntn_dir)?;
+    let staged = run_cmd_in_dir("git", &staged_args, &mntn_dir)?;
+
+    println!("Unstaged changes (working tree):");
+    if unstaged.trim().is_empty() {
+        println!("(none)");
+    } else {
+        println!("{}", unstaged);
+    }
+
+    println!();
+    println!("Staged changes (index):");
+    if staged.trim().is_empty() {
+        println!("(none)");
+    } else {
+        println!("{}", staged);
+    }
+
     Ok(())
 }
 

--- a/src/tasks/sync.rs
+++ b/src/tasks/sync.rs
@@ -3,6 +3,7 @@ use crate::logger::{log_info, log_success};
 use crate::tasks::core::{PlannedOperation, Task, TaskExecutor};
 use crate::utils::paths::get_mntn_dir;
 use crate::utils::system::run_cmd_in_dir;
+use anyhow::bail;
 use chrono::Utc;
 use std::fs;
 use std::io::Write;
@@ -45,7 +46,7 @@ impl Task for SyncTask {
         "Sync"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         let args = SyncArgs {
             init: self.init,
             remote_url: self.remote_url.clone(),
@@ -130,20 +131,18 @@ pub fn run_with_args(args: SyncArgs) {
     TaskExecutor::run(&mut task, args.dry_run);
 }
 
-fn sync_with_git(args: SyncArgs) -> Result<(), Box<dyn std::error::Error>> {
+fn sync_with_git(args: SyncArgs) -> anyhow::Result<()> {
     let mntn_dir = get_mntn_dir();
 
     if !mntn_dir.join(".git").exists() {
         if args.init {
             if args.remote_url.is_none() {
-                return Err("Remote URL is required when using --init".into());
+                bail!("Remote URL is required when using --init");
             }
             initialize_git_repo(&mntn_dir, args.remote_url.as_ref().unwrap())?;
             create_default_gitignore(&mntn_dir)?;
         } else {
-            return Err(
-                "No git repository found. Use --init with --remote-url to initialize.".into(),
-            );
+            bail!("No git repository found. Use --init with --remote-url to initialize.");
         }
     } else {
         if args.init {
@@ -190,10 +189,7 @@ fn sync_with_git(args: SyncArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn initialize_git_repo(
-    mntn_dir: &Path,
-    remote_url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn initialize_git_repo(mntn_dir: &Path, remote_url: &str) -> anyhow::Result<()> {
     println!("Initializing git repository in {}", mntn_dir.display());
 
     run_cmd_in_dir("git", &["init"], mntn_dir)?;
@@ -207,7 +203,7 @@ fn initialize_git_repo(
     Ok(())
 }
 
-fn create_default_gitignore(mntn_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn create_default_gitignore(mntn_dir: &Path) -> anyhow::Result<()> {
     let gitignore_path = mntn_dir.join(".gitignore");
     if !gitignore_path.exists() {
         let default_gitignore = "# mntn log files
@@ -236,14 +232,14 @@ Thumbs.db
     Ok(())
 }
 
-fn show_git_status() -> Result<(), Box<dyn std::error::Error>> {
+fn show_git_status() -> anyhow::Result<()> {
     let mntn_dir = get_mntn_dir();
     let output = run_cmd_in_dir("git", &["status", "--short", "--branch"], &mntn_dir)?;
     println!("{}", output);
     Ok(())
 }
 
-fn show_git_diff() -> Result<(), Box<dyn std::error::Error>> {
+fn show_git_diff() -> anyhow::Result<()> {
     let mntn_dir = get_mntn_dir();
     let unstaged_args = ["diff", "--color=always"];
     let staged_args = ["diff", "--staged", "--color=always"];
@@ -257,10 +253,7 @@ fn show_git_diff() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn run_staged_diff_with_fallback(
-    staged_args: &[&str],
-    mntn_dir: &Path,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+fn run_staged_diff_with_fallback(staged_args: &[&str], mntn_dir: &Path) -> anyhow::Result<Vec<u8>> {
     match run_git_diff_bytes(staged_args, mntn_dir) {
         Ok(output) => Ok(output),
         Err(_) => {
@@ -277,11 +270,11 @@ fn run_staged_diff_with_fallback(
     }
 }
 
-fn run_git_diff_bytes(
-    args: &[&str],
-    mntn_dir: &Path,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let output = Command::new("git").args(args).current_dir(mntn_dir).output()?;
+fn run_git_diff_bytes(args: &[&str], mntn_dir: &Path) -> anyhow::Result<Vec<u8>> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(mntn_dir)
+        .output()?;
 
     if !output.status.success() {
         let stderr_len = output.stderr.len();
@@ -298,7 +291,7 @@ fn run_git_diff_bytes(
     Ok(output.stdout)
 }
 
-fn print_diff_block(title: &str, content: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+fn print_diff_block(title: &str, content: &[u8]) -> anyhow::Result<()> {
     use std::io::Write;
 
     println!("{}", title);
@@ -317,7 +310,7 @@ fn print_diff_block(title: &str, content: &[u8]) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-fn ensure_gitignore_exists(mntn_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn ensure_gitignore_exists(mntn_dir: &Path) -> anyhow::Result<()> {
     let gitignore_path = mntn_dir.join(".gitignore");
     if !gitignore_path.exists() {
         create_default_gitignore(mntn_dir)?;

--- a/src/tasks/sync.rs
+++ b/src/tasks/sync.rs
@@ -21,7 +21,6 @@ pub struct SyncTask {
     pub dry_run: bool,
     pub status: bool,
     pub diff: bool,
-    pub diff_stat: bool,
 }
 
 impl SyncTask {
@@ -37,7 +36,6 @@ impl SyncTask {
             dry_run: args.dry_run,
             status: args.status,
             diff: args.diff,
-            diff_stat: args.diff_stat,
         }
     }
 }
@@ -59,19 +57,17 @@ impl Task for SyncTask {
             dry_run: self.dry_run,
             status: self.status,
             diff: self.diff,
-            diff_stat: self.diff_stat,
         };
 
         if args.status {
             show_git_status()?;
-            if !args.diff && !args.diff_stat {
+            if !args.diff {
                 return Ok(());
             }
         }
 
-        if args.diff || args.diff_stat {
-            let show_stat_only = args.diff_stat && !args.diff;
-            show_git_diff(show_stat_only)?;
+        if args.diff {
+            show_git_diff()?;
             return Ok(());
         }
 
@@ -86,18 +82,13 @@ impl Task for SyncTask {
 
         if self.status {
             operations.push(PlannedOperation::new("Show git status"));
-            if !self.diff && !self.diff_stat {
+            if !self.diff {
                 return operations;
             }
         }
 
-        if self.diff || self.diff_stat {
-            let label = if self.diff_stat && !self.diff {
-                "Show git diff summary"
-            } else {
-                "Show git diff"
-            };
-            operations.push(PlannedOperation::new(label));
+        if self.diff {
+            operations.push(PlannedOperation::new("Show git diff"));
             return operations;
         }
 
@@ -252,39 +243,44 @@ fn show_git_status() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn show_git_diff() -> Result<(), Box<dyn std::error::Error>> {
     let mntn_dir = get_mntn_dir();
-    let (unstaged_args, staged_args) = if show_stat_only {
-        (vec!["diff", "--stat"], vec!["diff", "--staged", "--stat"])
-    } else {
-        (vec!["diff"], vec!["diff", "--staged"])
-    };
+    let unstaged_args = ["diff", "--color=always"];
+    let staged_args = ["diff", "--staged", "--color=always"];
 
-    let unstaged = run_git_diff_lossy(&unstaged_args, &mntn_dir)?;
+    let unstaged = run_git_diff_bytes(&unstaged_args, &mntn_dir)?;
     let staged = run_staged_diff_with_fallback(&staged_args, &mntn_dir)?;
 
-    println!("Unstaged changes (working tree):");
-    if unstaged.trim().is_empty() {
-        println!("(none)");
-    } else {
-        println!("{}", unstaged);
-    }
-
-    println!();
-    println!("Staged changes (index):");
-    if staged.trim().is_empty() {
-        println!("(none)");
-    } else {
-        println!("{}", staged);
-    }
+    print_diff_block("Unstaged changes (working tree):", &unstaged)?;
+    print_diff_block("Staged changes (index):", &staged)?;
 
     Ok(())
 }
 
-fn run_git_diff_lossy(
+fn run_staged_diff_with_fallback(
+    staged_args: &[&str],
+    mntn_dir: &Path,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    match run_git_diff_bytes(staged_args, mntn_dir) {
+        Ok(output) => Ok(output),
+        Err(_) => {
+            let mut cached_args = Vec::with_capacity(staged_args.len());
+            for arg in staged_args {
+                if *arg == "--staged" {
+                    cached_args.push("--cached");
+                } else {
+                    cached_args.push(*arg);
+                }
+            }
+            run_git_diff_bytes(&cached_args, mntn_dir)
+        }
+    }
+}
+
+fn run_git_diff_bytes(
     args: &[&str],
     mntn_dir: &Path,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let output = Command::new("git").args(args).current_dir(mntn_dir).output()?;
 
     if !output.status.success() {
@@ -299,27 +295,26 @@ fn run_git_diff_lossy(
         .into());
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
-fn run_staged_diff_with_fallback(
-    staged_args: &[&str],
-    mntn_dir: &Path,
-) -> Result<String, Box<dyn std::error::Error>> {
-    match run_git_diff_lossy(staged_args, mntn_dir) {
-        Ok(output) => Ok(output),
-        Err(_) => {
-            let mut cached_args = Vec::with_capacity(staged_args.len());
-            for arg in staged_args {
-                if *arg == "--staged" {
-                    cached_args.push("--cached");
-                } else {
-                    cached_args.push(*arg);
-                }
-            }
-            run_git_diff_lossy(&cached_args, mntn_dir)
-        }
+fn print_diff_block(title: &str, content: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+
+    println!("{}", title);
+    if content.iter().all(|b| b.is_ascii_whitespace()) {
+        println!("(none)");
+        println!();
+        return Ok(());
     }
+
+    let mut stdout = std::io::stdout();
+    stdout.write_all(content)?;
+    if !content.ends_with(b"\n") {
+        stdout.write_all(b"\n")?;
+    }
+    println!();
+    Ok(())
 }
 
 fn ensure_gitignore_exists(mntn_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/tasks/sync.rs
+++ b/src/tasks/sync.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::process::Command;
 
 /// Sync task that synchronizes configurations with a git repository
 pub struct SyncTask {
@@ -259,7 +260,7 @@ fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>>
         (vec!["diff"], vec!["diff", "--staged"])
     };
 
-    let unstaged = run_cmd_in_dir("git", &unstaged_args, &mntn_dir)?;
+    let unstaged = run_git_diff_lossy(&unstaged_args, &mntn_dir)?;
     let staged = run_staged_diff_with_fallback(&staged_args, &mntn_dir)?;
 
     println!("Unstaged changes (working tree):");
@@ -280,11 +281,32 @@ fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+fn run_git_diff_lossy(
+    args: &[&str],
+    mntn_dir: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let output = Command::new("git").args(args).current_dir(mntn_dir).output()?;
+
+    if !output.status.success() {
+        let stderr_len = output.stderr.len();
+        let stderr_msg = String::from_utf8(output.stderr)
+            .unwrap_or_else(|_| format!("<non-UTF-8 stderr data: {} bytes>", stderr_len));
+        return Err(std::io::Error::other(format!(
+            "Command 'git' failed with status {:?}: {}",
+            output.status.code(),
+            stderr_msg
+        ))
+        .into());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 fn run_staged_diff_with_fallback(
     staged_args: &[&str],
     mntn_dir: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    match run_cmd_in_dir("git", staged_args, mntn_dir) {
+    match run_git_diff_lossy(staged_args, mntn_dir) {
         Ok(output) => Ok(output),
         Err(_) => {
             let mut cached_args = Vec::with_capacity(staged_args.len());
@@ -295,7 +317,7 @@ fn run_staged_diff_with_fallback(
                     cached_args.push(*arg);
                 }
             }
-            run_cmd_in_dir("git", &cached_args, mntn_dir)
+            run_git_diff_lossy(&cached_args, mntn_dir)
         }
     }
 }

--- a/src/tasks/sync.rs
+++ b/src/tasks/sync.rs
@@ -260,7 +260,7 @@ fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>>
     };
 
     let unstaged = run_cmd_in_dir("git", &unstaged_args, &mntn_dir)?;
-    let staged = run_cmd_in_dir("git", &staged_args, &mntn_dir)?;
+    let staged = run_staged_diff_with_fallback(&staged_args, &mntn_dir)?;
 
     println!("Unstaged changes (working tree):");
     if unstaged.trim().is_empty() {
@@ -278,6 +278,26 @@ fn show_git_diff(show_stat_only: bool) -> Result<(), Box<dyn std::error::Error>>
     }
 
     Ok(())
+}
+
+fn run_staged_diff_with_fallback(
+    staged_args: &[&str],
+    mntn_dir: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match run_cmd_in_dir("git", staged_args, mntn_dir) {
+        Ok(output) => Ok(output),
+        Err(_) => {
+            let mut cached_args = Vec::with_capacity(staged_args.len());
+            for arg in staged_args {
+                if *arg == "--staged" {
+                    cached_args.push("--cached");
+                } else {
+                    cached_args.push(*arg);
+                }
+            }
+            run_cmd_in_dir("git", &cached_args, mntn_dir)
+        }
+    }
 }
 
 fn ensure_gitignore_exists(mntn_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/tasks/use_profile.rs
+++ b/src/tasks/use_profile.rs
@@ -3,7 +3,7 @@ use crate::logger::{log_error, log_info, log_success, log_warning};
 use crate::profile::ProfileConfig;
 use crate::tasks::core::{PlannedOperation, Task, TaskExecutor};
 use crate::utils::paths::{clear_active_profile, get_active_profile_name, set_active_profile};
-use std::io;
+use anyhow::bail;
 
 pub struct UseProfileTask {
     profile_name: String,
@@ -24,7 +24,7 @@ impl Task for UseProfileTask {
         "Use Profile"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         let config = ProfileConfig::load_or_default();
 
         // Allow switching to "common" or "none" to clear active profile
@@ -40,10 +40,7 @@ impl Task for UseProfileTask {
             println!();
             println!("Create it with: mntn profile create {}", self.profile_name);
             println!("   Or list available profiles: mntn profile list");
-            return Err(Box::new(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("Profile '{}' does not exist", self.profile_name),
-            )));
+            bail!("Profile '{}' does not exist", self.profile_name);
         }
 
         // Check if already on this profile

--- a/src/tasks/validate.rs
+++ b/src/tasks/validate.rs
@@ -694,7 +694,7 @@ impl Task for ValidateTask {
         "Validate"
     }
 
-    fn execute(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute(&mut self) -> anyhow::Result<()> {
         println!("🔍 Validating configuration...");
         println!("   Profile: {}", self.profile);
         log("Starting validation");

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -215,25 +215,45 @@ mod tests {
 
     #[test]
     fn test_get_current_git_branch_returns_branch_name() {
+        if run_cmd("git", &["--version"]).is_err() {
+            return;
+        }
+
         let temp_dir = TempDir::new().unwrap();
         // Initialize a git repo and create a branch
-        let _ = run_cmd_in_dir("git", &["init"], temp_dir.path());
-        let _ = run_cmd_in_dir("git", &["checkout", "-b", "test-branch"], temp_dir.path());
+        if run_cmd_in_dir("git", &["init"], temp_dir.path()).is_err() {
+            return;
+        }
+        if run_cmd_in_dir("git", &["checkout", "-b", "test-branch"], temp_dir.path()).is_err() {
+            return;
+        }
         // Set user.name and user.email for CI environments before committing
-        let _ = run_cmd_in_dir(
+        if run_cmd_in_dir(
             "git",
             &["config", "user.name", "Test User"],
             temp_dir.path(),
-        );
-        let _ = run_cmd_in_dir(
+        )
+        .is_err()
+        {
+            return;
+        }
+        if run_cmd_in_dir(
             "git",
             &["config", "user.email", "test@example.com"],
             temp_dir.path(),
-        );
+        )
+        .is_err()
+        {
+            return;
+        }
         // Make an initial commit so HEAD points to the branch
         std::fs::write(temp_dir.path().join("file.txt"), "content").unwrap();
-        let _ = run_cmd_in_dir("git", &["add", "."], temp_dir.path());
-        let _ = run_cmd_in_dir("git", &["commit", "-m", "initial"], temp_dir.path());
+        if run_cmd_in_dir("git", &["add", "."], temp_dir.path()).is_err() {
+            return;
+        }
+        if run_cmd_in_dir("git", &["commit", "-m", "initial"], temp_dir.path()).is_err() {
+            return;
+        }
         let branch = get_current_git_branch(temp_dir.path());
         assert!(branch.is_ok());
         assert_eq!(branch.unwrap(), "test-branch");

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -1,3 +1,4 @@
+use crate::error::{AppError, Result};
 use regex::Regex;
 use std::io;
 use std::path::Path;
@@ -9,16 +10,12 @@ use std::process::Command;
 /// - Returns an `io::Error` if the command cannot be run.
 /// - Returns an error if the command exits with non-zero status.
 /// - Returns a `FromUtf8Error` if stdout isn't valid UTF-8.
-pub fn run_cmd(cmd: &str, args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
+pub fn run_cmd(cmd: &str, args: &[&str]) -> Result<String> {
     run_cmd_impl(cmd, args, None)
 }
 
 /// Run a command in a specific directory
-pub fn run_cmd_in_dir(
-    cmd: &str,
-    args: &[&str],
-    dir: &Path,
-) -> Result<String, Box<dyn std::error::Error>> {
+pub fn run_cmd_in_dir(cmd: &str, args: &[&str], dir: &Path) -> Result<String> {
     run_cmd_impl(cmd, args, Some(dir))
 }
 
@@ -30,17 +27,13 @@ pub fn strip_ansi_codes(input: &str) -> String {
 }
 
 /// Returns the current git branch name in the given directory.
-pub fn get_current_git_branch(dir: &std::path::Path) -> Result<String, Box<dyn std::error::Error>> {
+pub fn get_current_git_branch(dir: &std::path::Path) -> Result<String> {
     let branch = run_cmd_in_dir("git", &["rev-parse", "--abbrev-ref", "HEAD"], dir)?;
     Ok(branch.trim().to_string())
 }
 
 /// Internal implementation for running commands with optional directory
-fn run_cmd_impl(
-    cmd: &str,
-    args: &[&str],
-    dir: Option<&Path>,
-) -> Result<String, Box<dyn std::error::Error>> {
+fn run_cmd_impl(cmd: &str, args: &[&str], dir: Option<&Path>) -> Result<String> {
     let mut command = Command::new(cmd);
     command.args(args);
 
@@ -55,13 +48,11 @@ fn run_cmd_impl(
         let stderr_msg = String::from_utf8(output.stderr)
             .unwrap_or_else(|_| format!("<non-UTF-8 stderr data: {} bytes>", stderr_len));
 
-        return Err(io::Error::other(format!(
-            "Command '{}' failed with status {:?}: {}",
-            cmd,
-            output.status.code(),
-            stderr_msg
-        ))
-        .into());
+        return Err(AppError::CommandFailure {
+            cmd: cmd.to_string(),
+            status: output.status.code(),
+            stderr: stderr_msg,
+        });
     }
 
     let stdout = String::from_utf8(output.stdout)?;

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use std::io;
 use std::path::Path;
 use std::process::Command;
@@ -19,6 +20,13 @@ pub fn run_cmd_in_dir(
     dir: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
     run_cmd_impl(cmd, args, Some(dir))
+}
+
+/// Strips ANSI escape codes from a string.
+pub fn strip_ansi_codes(input: &str) -> String {
+    // Matches CSI (Control Sequence Introducer) ANSI escape codes.
+    let re = Regex::new(r"\x1B\[[0-?]*[ -/]*[@-~]").unwrap();
+    re.replace_all(input, "").to_string()
 }
 
 /// Returns the current git branch name in the given directory.
@@ -191,6 +199,13 @@ mod tests {
         let output = result.unwrap();
         assert!(output.contains("a.txt"));
         assert!(output.contains("b.txt"));
+    }
+
+    #[test]
+    fn test_strip_ansi_codes_removes_colors() {
+        let input = "\u{1b}[1mBold\u{1b}[0m \u{1b}[36mCyan\u{1b}[0m";
+        let output = strip_ansi_codes(input);
+        assert_eq!(output, "Bold Cyan");
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mntn sync --diff` command to display git diffs before syncing, with fallback support for older git versions.

* **Bug Fixes**
  * Fixed package registry command output to strip ANSI escape codes for cleaner display.

* **Documentation**
  * Added examples for `mntn sync --status` and `mntn sync --diff` commands in the Git Integration and Sync Guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->